### PR TITLE
choose fastest mirror when building container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # What's this?
 Configs and files for generating simple archlinux container by [mkosi](https://github.com/systemd/mkosi).
 
+This expects to use in Arch Linux.
+
 
 # How to use
-After cloning this repository, you could do belows:
+Install `base-devel`, `git`, `mkosi` and `reflector` and clone this repository.
+
+After cloning it, you could do belows:
 
 ## Creating container image
 ```

--- a/buildspawn/Makefile
+++ b/buildspawn/Makefile
@@ -5,11 +5,12 @@ MKOSI = mkosi.default.tmpl \
 		mkosi.nspawn
 NSPAWN = ${CONTAINER} \
 	${CONTAINER}.nspawn
+MIRROR=$(shell reflector --latest 10 --age 12 --sort rate | grep Server | grep https | cut -d ' ' -f 3 | head -1 | cut -d '/' -f -3)
 
 all: image
 
 image: ${MKOSI}
-	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' mkosi.default.tmpl > mkosi.default
+	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' -e 's|MIRROR|${MIRROR}|g' mkosi.default.tmpl > mkosi.default
 	mkosi build
 
 clean: ${NSPAWN}

--- a/buildspawn/mkosi.default.tmpl
+++ b/buildspawn/mkosi.default.tmpl
@@ -1,8 +1,9 @@
 [Distribution]
 Distribution=arch
+Mirror=MIRROR
 
 [Output]
-Format=raw_gpt
+Format=raw_btrfs
 Output=CONTAINER_NAME
 
 [Packages]

--- a/corespawn/Makefile
+++ b/corespawn/Makefile
@@ -5,11 +5,12 @@ MKOSI = mkosi.default.tmpl \
 		mkosi.nspawn
 NSPAWN = ${CONTAINER} \
 	${CONTAINER}.nspawn
+MIRROR=$(shell reflector --latest 10 --age 12 --sort rate | grep Server | grep https | cut -d ' ' -f 3 | head -1 | cut -d '/' -f -3)
 
 all: image
 
 image: ${MKOSI}
-	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' mkosi.default.tmpl > mkosi.default
+	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' -e 's|MIRROR|${MIRROR}|g' mkosi.default.tmpl > mkosi.default
 	mkosi build
 
 clean: ${NSPAWN}

--- a/corespawn/mkosi.default.tmpl
+++ b/corespawn/mkosi.default.tmpl
@@ -1,8 +1,9 @@
 [Distribution]
 Distribution=arch
+Mirror=MIRROR
 
 [Output]
-Format=raw_gpt
+Format=raw_btrfs
 Output=CONTAINER_NAME
 
 [Packages]

--- a/guispawn/Makefile
+++ b/guispawn/Makefile
@@ -5,11 +5,12 @@ MKOSI = mkosi.default.tmpl \
 		mkosi.nspawn
 NSPAWN = ${CONTAINER} \
 	${CONTAINER}.nspawn
+MIRROR=$(shell reflector --latest 10 --age 12 --sort rate | grep Server | grep https | cut -d ' ' -f 3 | head -1 | cut -d '/' -f -3)
 
 all: image
 
 image: ${MKOSI}
-	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' mkosi.default.tmpl > mkosi.default
+	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' -e 's|MIRROR|${MIRROR}|g' mkosi.default.tmpl > mkosi.default
 	mkosi build
 
 clean: ${NSPAWN}

--- a/guispawn/mkosi.default.tmpl
+++ b/guispawn/mkosi.default.tmpl
@@ -1,6 +1,6 @@
 [Distribution]
 Distribution=arch
-Mirror=https://jpn.mirror.pkgbuild.com
+Mirror=MIRROR
 
 [Output]
 Bootable=false

--- a/mstdnspawn/Makefile
+++ b/mstdnspawn/Makefile
@@ -5,11 +5,12 @@ MKOSI = mkosi.default.tmpl \
 		mkosi.nspawn
 NSPAWN = ${CONTAINER} \
 	${CONTAINER}.nspawn
+MIRROR=$(shell reflector --latest 10 --age 12 --sort rate | grep Server | grep https | cut -d ' ' -f 3 | head -1 | cut -d '/' -f -3)
 
 all: image
 
 image: ${MKOSI}
-	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' mkosi.default.tmpl > mkosi.default
+	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' -e 's|MIRROR|${MIRROR}|g' mkosi.default.tmpl > mkosi.default
 	mkosi build
 
 clean: ${NSPAWN}

--- a/mstdnspawn/mkosi.default.tmpl
+++ b/mstdnspawn/mkosi.default.tmpl
@@ -1,5 +1,6 @@
 [Distribution]
 Distribution=arch
+Mirror=MIRROR
 
 [Output]
 Format=raw_gpt

--- a/torspawn/Makefile
+++ b/torspawn/Makefile
@@ -5,11 +5,12 @@ MKOSI = mkosi.default.tmpl \
 		mkosi.nspawn
 NSPAWN = ${CONTAINER} \
 	${CONTAINER}.nspawn
+MIRROR=$(shell reflector --latest 10 --age 12 --sort rate | grep Server | grep https | cut -d ' ' -f 3 | head -1 | cut -d '/' -f -3)
 
 all: image
 
 image: ${MKOSI}
-	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' mkosi.default.tmpl > mkosi.default
+	sed -e 's/CONTAINER_NAME/${CONTAINER}/g' -e 's|MIRROR|${MIRROR}|g' mkosi.default.tmpl > mkosi.default
 	mkosi build
 
 clean: ${NSPAWN}

--- a/torspawn/mkosi.default.tmpl
+++ b/torspawn/mkosi.default.tmpl
@@ -1,5 +1,6 @@
 [Distribution]
 Distribution=arch
+Mirror=MIRROR
 
 [Output]
 Format=raw_btrfs
@@ -10,3 +11,6 @@ Packages=
 	polkit
 	privoxy
 	tor
+
+[Partitions]
+	RootSize=2147483648


### PR DESCRIPTION
Choose fastest mirror using `reflector`:
```
$ reflector --latest 10 --age 12 --sort rate | grep Server | grep https | cut -d ' ' -f 3 | head -1 | cut -d '/' -f -3
```
and set as `Mirror=` in `Distribution` section in `mkosi.default`.